### PR TITLE
Fix small formatting mistakes

### DIFF
--- a/docs/ocl/orocos-deployment.rst
+++ b/docs/ocl/orocos-deployment.rst
@@ -75,7 +75,7 @@ the DeploymentComponent is by default 'Deployer'. In order to change
 this name, use for example ``deployer-gnulinux NewDeployerName``. See
 also ``deployer-<target> --help`` for an overview of the options.
 
-    **Note**
+.. note::
 
     In case you set the OROCOS\_TARGET environment variable to the
     target you want to use (for example "gnulinux"), you can also start
@@ -139,25 +139,25 @@ options.
 
 Some examples are
 
-::
+.. code-block:: bash
 
-      deployer-corba --log-level warning -s myfile.xml
+    deployer-corba --log-level warning -s myfile.xml
 
 
 Sets the Orocos log level to ``warning`` and deploys file ``myfile.xml``
 
-::
+.. code-block:: bash
 
-      deployer-corba -l fatal --no-consolelog -s leftfile.xml LeftDeployer
+    deployer-corba -l fatal --no-consolelog -s leftfile.xml LeftDeployer
 
 
 Sets the Orocos log level to ``fatal``, turns off all logging to
 console, names the deployer ``LeftDeployer`` and deploys file
 ``leftfile.xml``
 
-::
+.. code-block:: bash
 
-      deployer-corba -l fatal --no-consolelog -s leftfile.xml LeftDeployer -- -ORBInitRef NameService=corbaloc:iiop:me.mine.home:2809/NameService -ORBFooBar 1
+    deployer-corba -l fatal --no-consolelog -s leftfile.xml LeftDeployer -- -ORBInitRef NameService=corbaloc:iiop:me.mine.home:2809/NameService -ORBFooBar 1
 
 
 As with the previous example, and also passes some options through to
@@ -206,7 +206,7 @@ components can be found, and which component libraries to import.
 
 Imagine that you have this directory structure:
 
-::
+.. code-block:: none
 
      /opt/robot                    : your orocos install path (lib, include, etc)
      /opt/robot/lib/orocos/        : orocos installed components
@@ -217,7 +217,7 @@ Imagine that you have this directory structure:
 And that you have a project 'robot-13' which is installed there as well,
 but in a subdirectory of the ``/opt/robot/lib/orocos`` directory:
 
-::
+.. code-block:: none
 
      /opt/robot/lib/orocos/robot-13         : robot-13 components
                           /robot-13/plugins : robot-13 services and other plugins
@@ -251,7 +251,7 @@ In XML, the path statement looks like:
 
 The script method equivalent is:
 
-::
+.. code-block:: none
 
       // note: small 'p':
       path("/opt/robot/lib/orocos")
@@ -283,7 +283,7 @@ In XML, the import statement looks like:
 
 The script method equivalent is:
 
-::
+.. code-block:: none
 
       // note: small 'i':
       import("robot-13")
@@ -304,7 +304,7 @@ available in the next step.
 To see the effects of the import function, the available types can be
 queried by invoking the ``displayComponentTypes`` (script) method:
 
-.. code-block:: rest
+.. code-block:: none
 
      (type 'ls' for context info) :displayComponentTypes()
           Got :displayComponentTypes()
@@ -335,7 +335,7 @@ the 'Include' directive. The include directive may occur at any place in
 the XML file (but under <properties>) and will be processed as-if the
 included file is inserted at that point.
 
-    **Warning**
+.. warning::
 
     This option is new and experimental and may change in meaning and/or
     name in the future. When using the Xerces XML parser in Orocos, you
@@ -392,7 +392,7 @@ component, which is exported using the ``ORO_CREATE_COMPONENT`` macro
 
 The script method equivalent is:
 
-::
+.. code-block:: none
 
       loadComponent("Reporter", "OCL::FileReporting")
 
@@ -563,14 +563,14 @@ You can check the available services or plugins (ie discovered by the
 DeploymentComponent) with '.services' or '.plugins' and load a service
 from the TaskBrowser prompt *in the current visited component* with
 
-::
+.. code-block:: none
 
     .provide
             <servicename>
 
 . The Deployer has the equivalent function which looks like this:
 
-::
+.. code-block:: none
 
       loadService("Reporter","scripting")
 
@@ -599,7 +599,7 @@ start() method will be called during ``startComponents()``. By default
 There is no literal alternative for AutoConf in scripting. Just use the
 ``configure()`` operation of your component in order to configure it:
 
-::
+.. code-block:: none
 
       Controller.configure()
       Controller.start()
@@ -664,7 +664,7 @@ the ``AutoConnect`` flag. If an automatic port connection fails, the
 configuration procedure will not fail and just continue. An error
 message may be logged. By default, ``AutoConnect`` is 0 (off).
 
-    **Note**
+.. note::
 
     AutoConnect is only useful for simple applications, use the explicit
     'Ports' connection method to connect different named ports to each
@@ -673,7 +673,7 @@ message may be logged. By default, ``AutoConnect`` is 0 (off).
 In scripting, you can use the ``ConnPolicy`` struct for connecting
 ports. For example:
 
-::
+.. code-block:: none
 
       var ConnPolicy cp
       cp.type = BUFFER
@@ -730,7 +730,7 @@ of the Component, just before the Component is ``cleanup()``.
 In scripting, you can use the ``marshalling`` service in order to do the
 property loading for you. For example:
 
-::
+.. code-block:: none
 
       loadService("MyComponent","marshalling")
       MyComponent.marshalling.readProperties("file.cpf")
@@ -763,7 +763,7 @@ and control it. For example, use its services, start and stop it etc.
 Loading and Running Orocos Program Scripts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    **Note**
+.. note::
 
     This section is for starting scripts from the XML file. In case you
     want to use a script directly (or after an XML file), you can use
@@ -787,7 +787,7 @@ again done during the ``configureComponents()`` step.
 If you want to have a program or statemachine started you need to do so
 at the end of the script file itself, by adding
 
-::
+.. code-block:: none
 
       programname.start()
       statemachine_instance.activate()
@@ -797,7 +797,7 @@ statements. Be aware that this is done during the configuration phase of
 your components, so before updateHook() is executed. You are however
 allowed to start your component from the script by merely calling
 
-::
+.. code-block:: none
 
       start()
 
@@ -832,7 +832,7 @@ scripts, since scripts need periodic execution in case they have to wait
 for an operation to complete. Alternatively, you can set the period at
 the top of your script file by adding the statement:
 
-::
+.. code-block:: none
 
       setPeriod(0.01)
 
@@ -872,7 +872,7 @@ Naming Service to register its name. If this is not wanted, set the
 
 The script method equivalent of the above XML construct is:
 
-::
+.. code-block:: none
 
       server("Reporter", true)
 
@@ -909,7 +909,7 @@ using the same name as the original. This also works for the scripting
 deployer command 'loadComponent'. For example, you can type in the
 TaskBrowser:
 
-::
+.. code-block:: none
 
       loadComponent("MyComponent", "CORBA")
       loadComponent("MyComponent.ior", "IORFile")
@@ -924,7 +924,7 @@ Setting up a deployable component library
 This section explains how to prepare a component library for deployment.
 It is demonstrated with an example.
 
-    **Note**
+.. note::
 
     The ``orocreate-pkg`` script of OCL does all the setup work for you.
     This section is given for reference use only.
@@ -939,7 +939,7 @@ component type. Assume we have written the ``OCL::HelloWorld`` component
 ``orocos-helloworld.so`` library. The following code is added to
 HelloWorld.cpp:
 
-::
+.. code-block:: cpp
 
       #include "HelloWorld.hpp"
       #include <ocl/Component.hpp>
@@ -958,7 +958,7 @@ once for the whole library. Say your library has components
 NS::\ ``ComponentX`` and NS::\ ``ComponentZ`` in namespace NS. In order
 to export both components, you could write in ``ComponentX.cpp``:
 
-::
+.. code-block:: cpp
 
       #include "ComponentX.hpp"
       #include <ocl/Component.hpp>
@@ -972,7 +972,7 @@ to export both components, you could write in ``ComponentX.cpp``:
 and in ``ComponentY.cpp`` the same but without the
 ORO\_CREATE\_COMPONENT\_LIBRARY macro:
 
-::
+.. code-block:: cpp
 
       #include "ComponentY.hpp"
       #include <ocl/Component.hpp>
@@ -986,12 +986,10 @@ For each additional component in the same library, the
 ORO\_LIST\_COMPONENT\_TYPE macro is added. It is allowed to put all the
 ORO\_LIST\_COMPONENT\_TYPE macros in a single file.
 
-    **Note**
+.. note::
 
     You may not link multiple libraries that use ORO\_CREATE\_COMPONENT,
     since only one of the component types will be found.
-
-    **Note**
 
     ORO\_CREATE\_COMPONENT\_LIBRARY() replaces the pre-2.3.0
     ORO\_CREATE\_COMPONENT\_TYPE() macro. The old macro is still kept
@@ -1007,7 +1005,7 @@ static library will not be dynamically loadable. In the final executable
 the DeploymentComponent will be able to find the linked in components
 and setup the application using the XML file.
 
-    **Important**
+.. important::
 
     The macros need some help to figure out if you are compiling a
     shared or static library. You need to define the *RTT\_COMPONENT*
@@ -1031,7 +1029,7 @@ options :
       CFLAGS= -O2 -Wall
       LDFLAGS=
 
-**Note**
+.. note::
 
   If you use CMake with the UseOrocos.cmake macros, you don't need any
   of this manual setup. The Orocos macros set the right flags for you.

--- a/docs/ocl/orocos-reporting.rst
+++ b/docs/ocl/orocos-reporting.rst
@@ -161,7 +161,7 @@ Reading the configuration file
 The property file of the reporting component *must* be read with the
 loadProperties script method:
 
-::
+.. code-block:: none
 
       marshalling.loadProperties("reporting.cpf")
 
@@ -170,7 +170,7 @@ loads your ``ReportData`` struct into the ReportingComponent.
 
 With
 
-::
+.. code-block:: none
 
       marshalling.writeProperties("reporting.cpf")
 

--- a/docs/rtt/orocos-corelib.rst
+++ b/docs/rtt/orocos-corelib.rst
@@ -72,7 +72,7 @@ There are two ways to run a function in a periodically. By :
    activity using activity.run( &run\_impl ) or at construction time of
    an Activity : Activity activity(priority, period, &run\_impl );.
 
-   ::
+   .. code-block:: cpp
 
          #include <rtt/RunnableInterface.hpp>
          #include <rtt/Activity.hpp>
@@ -123,7 +123,7 @@ There are two ways to run a function in a periodically. By :
 -  Inheriting from an Activity class and overriding the initialize(),
    step() and finalize() methods.
 
-   ::
+   .. code-block:: cpp
 
          class MyOtherPeriodicFunction
              : public RTT::Activity
@@ -172,7 +172,7 @@ to a periodic Activity, the user can implement ``initialize()``,
 executing the user's functions. Alternatively, you can reimplement said
 functions in a derived class of Activity.
 
-::
+.. code-block:: cpp
 
       int priority = 5;
 
@@ -217,7 +217,7 @@ scheduler type, by providing an extra argument during construction. When
 a priority is specified, the Activity selects the the ORO\_SCHED\_RT
 scheduler.
 
-::
+.. code-block:: cpp
 
       // Equivalent to Activity my_act(OS::HighestPriority, 0.001) :
       Activity my_act(ORO_SCHED_RT, OS::HighestPriority, 0.001);
@@ -236,7 +236,7 @@ implemented which will execute ``RunnableInterface::step()`` or
 ``RunnableInterface::loop()`` when called by the user. Three versions of
 the ``SlaveActivity`` can be constructed:
 
-::
+.. code-block:: cpp
 
       #include <rtt/SlaveActivity.hpp>
 
@@ -289,12 +289,12 @@ information such as the priority and periodicity and allows to control
 the real-timeness of the thread which runs this activity. A non periodic
 activity's thread will return a period of zero.
 
-A ``RTT::base::RunnableInterface`` can get the same information through
+An ``RTT::base::RunnableInterface`` can get the same information through
 the ``this->getActivity()->thread()`` method calls.
 
 This example shows how to manipulate a thread.
 
-::
+.. code-block:: cpp
 
     #include "rtt/ActivityInterface.hpp"
 
@@ -338,7 +338,7 @@ Signal Basics
 
 This example shows how a handler is connected to an Signal.
 
-::
+.. code-block:: cpp
 
      #include <rtt/internal/Signal.hpp>
 
@@ -358,7 +358,7 @@ Now we will connect the handler function to a signal. Each event-handler
 connection is stored in a Handle object, for later reference and
 connection management.
 
-::
+.. code-block:: cpp
 
      // The <..> means the callback functions must be of type "void foo(void)"
      RTT::internal::Signal<void(void)> emergencyStop;
@@ -376,14 +376,14 @@ connection management.
 
 Finally, we emit the event and see how the handler functions are called:
 
-::
+.. code-block:: cpp
 
      std::cout << "Emit/Call the event\n";
      emergencyStop();
 
 The program will output these messages:
 
-::
+.. code-block:: none
 
          Register appropriate handlers to the Emergency Stop Signal
          Emit the event
@@ -395,7 +395,7 @@ manual <http://www.boost.org/libs/bind/bind.html>`__. You must use bind
 if you want to call C++ class member functions to 'bind' the member
 function to an object :
 
-::
+.. code-block:: cpp
 
       ClassName object;
       boost::bind( &ClassName::FunctionName, &object)
@@ -403,7 +403,7 @@ function to an object :
 Where ClassName::FunctionName must have the same signature as the
 Signal. When the Signal is called,
 
-::
+.. code-block:: cpp
 
       object->FunctionName( args )
 
@@ -411,7 +411,7 @@ is executed by the Signal.
 
 When you want to call free ( C ) functions, you do not need bind :
 
-::
+.. code-block:: cpp
 
       Signal<void(void)> event;
       void foo() { ... }
@@ -422,7 +422,7 @@ This can no longer be changed once the ``RTT::internal::Signal`` is
 created. If the type changes, the event() method must given other
 arguments. For example :
 
-::
+.. code-block:: cpp
 
       RTT::internal::Signal<void(void)> e_1;
       e_1();
@@ -436,7 +436,7 @@ arguments. For example :
 Furthermore, you need to setup the connect call differently if the
 Signal carries one or more arguments :
 
-::
+.. code-block:: cpp
 
       SomeClass someclass;
 
@@ -459,7 +459,7 @@ On ``setup()`` and the ``RTT::Handle`` object
 Signal connections can be managed by using a Handle which both
 ``connect()`` and ``setup()`` return :
 
-::
+.. code-block:: cpp
 
       RTT::internal::Signal<void(int, float)> event;
       RTT::Handle eh;
@@ -480,7 +480,7 @@ Signal connections can be managed by using a Handle which both
 Handle objects can be copied and will all show the same status. To have
 a connection setup, but not connected, one can write :
 
-::
+.. code-block:: cpp
 
       RTT::internal::Signal<void(int, float)> event;
       RTT::Handle eh;
@@ -522,7 +522,7 @@ Usage Example
 
 Also take a look at the interface documentation.
 
-::
+.. code-block:: cpp
 
       #include <rtt/os/TimeService.hpp>
       #include <rtt/Time.hpp>
@@ -546,7 +546,7 @@ network connection.
 The advantages of this class come clear when building Orocos Components,
 since it allows a component to make internal data to its scripts.
 
-::
+.. code-block:: cpp
 
       // an attribute, representing a double of value 1.0:
       RTT::Attribute<double> myAttr(1.0);
@@ -580,20 +580,22 @@ change the values as they see fit. Java for example presents a Property
 API. The Doxygen Property API should provide enough information for
 successfully using them in your Software Component.
 
-    **Note**
+.. note::
 
     Reading and writing a properties value can be done in real-time.
     Every other transaction, like marshaling (writing to disk),
     demarshaling (reading from disk) or building the property is not a
     real-time operation.
 
-    ::
+..
 
-          // a property, representing a double of value 1.0:
+.. code-block:: cpp
 
-          RTT::Property<double> myProp("Parameter A","A demo parameter", 1.0); // not real-time !
-          myProp = 10.9; // real-time
-          double a = myProp.get(); // real-time
+      // a property, representing a double of value 1.0:
+
+      RTT::Property<double> myProp("Parameter A","A demo parameter", 1.0); // not real-time !
+      myProp = 10.9; // real-time
+      double a = myProp.get(); // real-time
 
 Properties are mainly used for two purposes. First, they allow an
 external entity to browse their contents, as they can form hierarchies
@@ -617,7 +619,7 @@ recursive operations on a bag, you can use the helper functions we
 created and which are defined in ``PropertyBag.hpp`` (see Doxygen
 documentation). These operations are however, most likely not real-time.
 
-    **Note**
+.. note
 
     When you want to put a PropertyBag into another PropertyBag, you
     need to make a Property<PropertyBag> and insert that property into
@@ -629,7 +631,7 @@ property which is stored in a PropertyBag: the property object's value
 acts like the original. The name and description are not mirrored, only
 copied upon initialisation:
 
-::
+.. code-block
 
       RTT::PropertyBag bag;
       RTT::Property<double> w("Weight", "in kilograms", 70.5 );
@@ -716,7 +718,7 @@ typed buffer of type *T* and works as a FIFO queue for storing elements
 of type T. It is lock-free, non blocking and read and writes happen in
 bounded time. It is not subject to priority inversions.
 
-::
+.. code-block:: cpp
 
       #include <rtt/BufferLockFree.hpp>
 
@@ -745,7 +747,7 @@ semantics than just (vectors of) doubles. The default constructor of the
 data is called when the DataObject is constructed. Here is an example of
 creating and using a DataObject :
 
-::
+.. code-block:: cpp
 
       #include <rtt/DataObjectInterfaces.hpp>
 
@@ -769,7 +771,7 @@ Orocos applications can have pretty complex start-up and initialisation
 code. A logging framework, using ``RTT::Logger`` helps to track what
 your program is doing.
 
-    **Note**
+.. note::
 
     Logging can only be done in the non-real-time parts of your
     application, thus not in the Real-time Periodic Activities !
@@ -803,7 +805,7 @@ Table: Logger Log Levels
 You can change the amount of log info printed on your console by setting
 the environment variable ORO\_LOGLEVEL to one of the above numbers :
 
-::
+.. code-block:: bash
 
       export ORO_LOGLEVEL=5
 
@@ -817,7 +819,7 @@ information of what is happening inside Orocos.
 
 If you want to disable logging completely, use
 
-::
+.. code-block:: bash
 
     export ORO_LOGLEVEL=-1
 
@@ -826,7 +828,7 @@ before you start your program.
 For using the ``RTT::Logger`` class in your own application, consult the
 API documentation.
 
-::
+.. code-block:: cpp
 
       #include <rtt/Logger.hpp>
 
@@ -842,7 +844,7 @@ in front (using log() ) or at the end (using endlog()) of the log
 message. When no log level is specified, the previously set level is
 used. The above message could result in :
 
-::
+.. code-block:: none
 
       0.123 [ ERROR  ][MyModule] An error Occured : 333
       0.124 [ Debug  ][MyModule] <contents of debugstring and data >

--- a/docs/rtt/orocos-device-interface.rst
+++ b/docs/rtt/orocos-device-interface.rst
@@ -127,10 +127,9 @@ device layer can be queried for entities, since logical device drivers
 are typically instantiated where needed, given an earlier loaded
 physical device driver.
 
-`example\_title <#example_name_service>`__ shows how one could query the
-``RTT::DigitalOutInterface``.
+The example below shows how one could query the ``RTT::DigitalOutInterface``.
 
-::
+.. code-block:: cpp
 
       FancyCard* fc = new FancyCard("CardName"); // FancyCard implements DigitalOutInterface
 

--- a/docs/rtt/orocos-os.rst
+++ b/docs/rtt/orocos-os.rst
@@ -123,12 +123,14 @@ done. Inside ORO\_main() the user may expect that the system is properly
 set up and can be used. The resulting orocos-rtt library will contain
 the real main() function which will call the ORO\_main() function.
 
-    **Important**
+.. important::
 
     Do not forget to include ``<rtt/os/main.h>`` in the main program
     file, or the linker will not find the ORO\_main function.
 
-    **Note**
+..
+
+.. note::
 
     Using global objects ( or *static* class members ) which use the OS
     functions before ORO\_main() is entered (because they are
@@ -181,7 +183,7 @@ its stop() method if loop() is still being executed and, if successful,
 will wait until loop() returns. The ``Thread::isRunning()`` function can
 be used to check if loop() is being executed or not.
 
-    **Note**
+.. note::
 
     The ``RTT::Activity`` provides a better integrated implementation
     for SingleThread and should be favourably used.
@@ -232,7 +234,7 @@ entered, the pin will be set high, and when step() is left, the pin is
 set low again. From within any RTT activity function, you may then
 additionally use the ThreadScope driver as such :
 
-::
+.. code-block:: cpp
 
       RTT::DigitalOutInterface* pp = DigitalOutInterface::nameserver.getObject("ThreadScope");
     if ( pp )
@@ -264,7 +266,7 @@ given Mutex is locked. This is called a scoped lock.
 
 The first listing shows a complete lock over a function :
 
-::
+.. code-block:: cpp
 
       RTT::os::Mutex m;
       void foo() {
@@ -277,7 +279,7 @@ The first listing shows a complete lock over a function :
 Any scope is valid, so if the critical section is smaller than the size
 of the function, you can :
 
-::
+.. code-block:: cpp
 
       RTT::os::Mutex m;
       void bar() {
@@ -300,7 +302,7 @@ Orocos provides a C++ semaphore abstraction class
 tasks or threads. The higher level Event implementation in CoreLib can
 be used for thread safe signalling and data exchange in periodic tasks.
 
-::
+.. code-block:: cpp
 
       RTT::os::Semaphore sem(0); // initial value is zero.
       void foo() {

--- a/docs/rtt/orocos-rtt-scripting.rst
+++ b/docs/rtt/orocos-rtt-scripting.rst
@@ -30,7 +30,7 @@ Comments
 Various sorts of comments are supported in the syntax. Here is a small
 listing showing the various syntaxes:
 
-::
+.. code-block:: none
 
       # A perl-style comment, starting at a '#', and running until
       # the end of the line.
@@ -88,7 +88,7 @@ difference with integers, we require a dot to be present. String
 literals are surrounded by double quotes, and can contain all the normal
 C/C++ style escaped characters. Here are some examples:
 
-::
+.. code-block:: none
 
       // a string with some escaped letters:
       "\"OROCOS rocks, \" my mother said..."
@@ -111,7 +111,7 @@ defined with an expression, for which it acts as an alias or an
 *abbreviation* during the rest of the program. All of them can always be
 used as expressions. Here is some code showing how to use them.
 
-::
+.. code-block:: none
 
       // define a variable of type int, called counter,
       // and give it the initial value 0.
@@ -165,27 +165,27 @@ constructors:
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
 | Copy Syntax (copy done at run-time)        | Pre-allocate syntax (init done at parse-time)   | Notes                                                                                      |
 +============================================+=================================================+============================================================================================+
-| ::                                         | ::                                              | Creates an empty string. (``std::string``)                                                 |
+| .. code-block:: none                       | .. code-block:: none                            | Creates an empty string. (``std::string``)                                                 |
 |                                            |                                                 |                                                                                            |
 |     var string x = string()                |     var string x                                |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ::                                         | ::                                              | Creates a string with contents "Hello World".                                              |
+| .. code-block:: none                       | .. code-block:: none                            | Creates a string with contents "Hello World".                                              |
 |                                            |                                                 |                                                                                            |
 |     var string x = string("Hello World")   |     var string x("Hello World")                 |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ::                                         | ::                                              | Creates an empty array. (``std::vector<double>)``                                          |
+| .. code-block:: none                       | .. code-block:: none                            | Creates an empty array. (``std::vector<double>)``                                          |
 |                                            |                                                 |                                                                                            |
 |     var array x = array()                  |     var array x                                 |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ::                                         | ::                                              | Creates an array with 10 elements, all equal to 0.0.                                       |
+| .. code-block:: none                       | .. code-block:: none                            | Creates an array with 10 elements, all equal to 0.0.                                       |
 |                                            |                                                 |                                                                                            |
 |     var array x = array(10)                |     var array x(10)                             |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ::                                         | ::                                              | Creates an array with 10 elements, all equal to 3.0.                                       |
+| .. code-block:: none                       | .. code-block:: none                            | Creates an array with 10 elements, all equal to 3.0.                                       |
 |                                            |                                                 |                                                                                            |
 |     var array x = array(10, 3.0)           |     var array x(10, 3.0)                        |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
-| ::                                         | ::                                              | Creates an array with 3 elements: {1.0, 2.0, 3.0}. Any number of arguments may be given.   |
+| .. code-block:: none                       | .. code-block:: none                            | Creates an array with 3 elements: {1.0, 2.0, 3.0}. Any number of arguments may be given.   |
 |                                            |                                                 |                                                                                            |
 |     var array x = array(1.0, 2.0, 3.0)     |     var array x(1.0, 2.0, 3.0)                  |                                                                                            |
 +--------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------+
@@ -236,7 +236,7 @@ Table: array and string constructors
       in the examples ), but if you create a Task constant or variable
       which holds an integer, you can also use it as in :
 
-::
+.. code-block:: none
 
       var array example( 5 * numberOfItems )
 
@@ -246,7 +246,7 @@ Table: array and string constructors
       be zero upon parse time ! The following example is *a common
       mistake* also :
 
-::
+.. code-block:: none
 
       numberOfItems = 10
       var array example( 5 * numberOfItems )
@@ -259,7 +259,7 @@ Table: array and string constructors
 Another property of container types is that you can index (use []) their
 contents. The index may be any expression that return an int.
 
-::
+.. code-block:: none
 
       // ... continued
       // Set an item of a container :
@@ -292,7 +292,7 @@ When a data type is a C++ struct or class, it contains fields which you
 might want to access directly. These can be accessed for reading or
 writing by using a dot '.' and the name of the field:
 
-::
+.. code-block:: none
 
       var mydata d1;
 
@@ -302,7 +302,7 @@ writing by using a dot '.' and the name of the field:
 Some value types, like array and string, are containing *read-only*
 values or useful information about their size and capacity:
 
-::
+.. code-block:: none
 
       var string s1 = "abcdef"
 
@@ -310,7 +310,7 @@ values or useful information about their size and capacity:
       var int size = s1.size
       var int cap  = s1.capacity
 
-::
+.. code-block:: none
 
       var array a1( 10 )
       var array a2(20) = a1
@@ -356,7 +356,7 @@ In C++ code
 Parsing the program is done using the 'getProvider' function to call the
 scripting service's functions:
 
-::
+.. code-block:: cpp
 
       #include <rtt/Activity.hpp>
       #include <rtt/TaskContext.hpp>
@@ -381,7 +381,7 @@ In case you wish to have a pointer to a program script object
 (``RTT::scripting::ProgramInterface``), you can have so only from within
 the owner TaskContext by writing:
 
-::
+.. code-block:: cpp
 
       // Services are always accessed using a shared_ptr
       // cast the "scripting" RTT::Service to an RTT::scripting::ScriptingService shared_ptr:
@@ -422,7 +422,7 @@ Program Syntax
 
 A program is formed like this:
 
-::
+.. code-block:: none
 
       program progname {
         // an arbitrary number of statements
@@ -441,7 +441,7 @@ Variables and Assignments
 A variable is declared with the ``var`` keyword and can be changed using
 the ``=`` symbol. It looks like this:
 
-::
+.. code-block:: none
 
       var int a, b, c;
       a = 3 * (b = (5 * (c = 1))); // a = 15, b = 5, c = 1
@@ -457,7 +457,7 @@ A Program script can contain if..then..else blocks, very similar to C
 syntax, except that the *then* word is mandatory and that the braces ()
 can be omitted. For example:
 
-::
+.. code-block:: none
 
       var int x = 3
 
@@ -486,7 +486,7 @@ initialises a variable or is empty. The condition contains a boolean
 expression (use 'true' to simulate an empty condition). The second
 statement changes a variable or is empty.
 
-::
+.. code-block:: none
 
       // note the var when declaring i:
       for ( var int i = 0; i != 10; i = i + 1 )
@@ -531,7 +531,7 @@ The break Statement
 To break out of a while or for loop, the break statement is available.
 It will break out of the innermost loop, in case of nesting.
 
-::
+.. code-block:: none
 
       var int i = 0
       while true  {
@@ -581,7 +581,7 @@ state and waits for user intervention. This can be intercepted by using
 a *try...catch* statement. It tries to execute the method, and if it
 throws, the optional catch clause is executed :
 
-::
+.. code-block:: none
 
       // just try ignores the exception of action :
       try comp.action( args )
@@ -601,7 +601,7 @@ Setting Task Attributes and Properties
 Task attributes/Properties are set in the same way as ordinary script
 variables.
 
-::
+.. code-block:: none
 
       // Setting a property named MyProp of type double
       var double d = 5.0
@@ -614,7 +614,7 @@ Statements can be grouped in functions. A function can only call another
 function which is earlier defined. Thus recursive function calling is
 not allowed in this language.
 
-::
+.. code-block:: none
 
       // A function only known in the current scripting service
       void func_name( int arg1, double arg2 ) {
@@ -663,7 +663,7 @@ Calling functions
 
 A function can be called as a regular Operation :
 
-::
+.. code-block:: none
 
       foo(arg)      // is a global, local or exported function of the current component
 
@@ -684,7 +684,7 @@ The return statement behaves like in traditional languages. For programs
 and functions that do not return a value, the return statement is
 written like:
 
-::
+.. code-block:: none
 
       export void foo(int i) {
          // ...
@@ -696,7 +696,7 @@ written like:
 When the return statement returns a value, it must be on the same line
 as the return word:
 
-::
+.. code-block:: none
 
       export int foo(int i) {
          // ...
@@ -717,7 +717,7 @@ execution of the current script and allows the Execution Engine in which
 it runs to do something else. You will need this in an endless while
 loop, for example:
 
-::
+.. code-block:: none
 
       while( true ) {
         log("Waiting...")
@@ -738,7 +738,7 @@ manipulated from another script. This can be done through the programs
 subtask of the TaskContext in which the program was loaded. Assume that
 you loaded "progname" in task "ATask", you can write
 
-::
+.. code-block:: none
 
       ATask.progname.start()
       ATask.progname.pause()
@@ -752,7 +752,7 @@ debugger). The last line stops the program fully (running or paused).
 
 Some basic properties of the program can be inspected likewise :
 
-::
+.. code-block:: none
 
       var bool res =  ATask.progname.isRunning()
       res = ATask.progname.inError()
@@ -906,7 +906,7 @@ In C++ code
 
 Parsing the StateMachine is very analogous to parsing Programs in C++:
 
-::
+.. code-block:: cpp
 
       #include <rtt/Activity.hpp>
       #include <rtt/TaskContext.hpp>
@@ -935,7 +935,7 @@ In case you wish to have a pointer to a state machine script object
 (``RTT::scripting::StateMachine``), you can have so only from within the
 owner TaskContext by writing:
 
-::
+.. code-block:: cpp
 
       // Services are always accessed using a shared_ptr
       // cast the "scripting" RTT::Service to an RTT::scripting::ScriptingService shared_ptr:
@@ -961,7 +961,7 @@ parameters it got in its instantiation.
 
 A StateMachine definition looks like this :
 
-::
+.. code-block:: none
 
       StateMachine MyStateMachineDefinition
       {
@@ -1044,7 +1044,7 @@ transition can be found to another state. The transitions section
 defines one or more ``select`` *state* statements. These can be guarded
 by if...then clauses (the transition conditions):
 
-::
+.. code-block:: none
 
       // In state XYZ :
       // conditionally select the START state
@@ -1081,7 +1081,7 @@ preconditions will be checked before the state is entered.
 
 Preconditions are specified as follows:
 
-::
+.. code-block:: none
 
       state X {
         // make sure the robot is not moving axis 1 when entering this state
@@ -1114,7 +1114,7 @@ Event transitions are an extension to the transitions above and cite an
 InputPort name between the transition and the if statement. They are
 specified as:
 
-::
+.. code-block:: none
 
       state X {
         var double d
@@ -1132,7 +1132,7 @@ specified as:
 Both the transition programs and the the select statements are optional,
 but at least a program or select statement must be given. The
 
-::
+.. code-block:: none
 
       transition x_in_port(d) if (d >1.3) then {
 
@@ -1140,7 +1140,7 @@ but at least a program or select statement must be given. The
 short notation statement is equivalent to writing (NOTE: the added
 .read(d) part) :
 
-::
+.. code-block:: none
 
       transition if ( x_in_port.read(d) == NewData && d >1.3) then {...
 
@@ -1183,7 +1183,7 @@ events instead of edge events as seen above. The syntax for level events
 shows that the port must be read out in the if statement, as a normal
 port read:
 
-::
+.. code-block:: none
 
       transition if (robotState.read(robot_state) != NoData && Robot.STATE_SAFE == robot_state) select SAFE;
 
@@ -1201,7 +1201,7 @@ TaskContext the state machine runs in. In order to respond in a state
 machine to such an event, the operation needs to be added with the
 addEventOperation function:
 
-::
+.. code-block:: none
 
       // member variable of 'MyComp':
       Operation<void(int)> requestSafe; // don't forget to initialize with a "name" in the constructor.
@@ -1225,7 +1225,7 @@ addEventOperation function:
 Reacting to an Operation call is similar to responding to port events
 above:
 
-::
+.. code-block:: none
 
       state X {
         var int reason;
@@ -1264,7 +1264,7 @@ A Root Machine is a normal instantiation of a StateMachine, one that
 does not depend on a parent StateMachine ( see below ). They are defined
 as follows:
 
-::
+.. code-block:: none
 
       StateMachine SomeStateMachine
       {
@@ -1297,7 +1297,7 @@ below ) the parent Machine.
 
 You can define a StateMachine public variable as follows:
 
-::
+.. code-block:: none
 
       StateMachine SomeStateMachine
       {
@@ -1330,7 +1330,7 @@ This example creates some handy public variables in the StateMachine
 SomeStateMachine, and uses them throughout the state machine. They can
 also be read and modified from other tasks or programs :
 
-::
+.. code-block:: none
 
       var int readcounter = 0
       readcounter = taskname.mymachine.counter
@@ -1343,7 +1343,7 @@ StateMachine parameters
 A StateMachine can have parameters that need to be set on its
 instantiation. Here's an example:
 
-::
+.. code-block:: none
 
       StateMachine AxisController
       {
@@ -1388,7 +1388,7 @@ Instantiating SubMachines
 
 An instantiation of a SubMachine is written as follows:
 
-::
+.. code-block:: none
 
       StateMachine ChildStateMachine
       {
@@ -1453,7 +1453,7 @@ However, you can still change the values of the parameters afterwards.
 The syntax is: "set someSubMachine.someParam = someExpression". Here's
 an elaborate example:
 
-::
+.. code-block:: none
 
       StateMachine ChildStateMachine
       {
@@ -1510,7 +1510,7 @@ an elaborate example:
 You can also query if a child State Machine is in a certain state. The
 syntax looks like:
 
-::
+.. code-block:: none
 
     someSubMachine.inState( "someStateName" )
 
@@ -1524,7 +1524,7 @@ through the "states" subtask of the TaskContext in which the state
 machine was loaded. Assume that you loaded "machine" with subcontexts
 "axisx" and "axisy" in task "ATask", you can write
 
-::
+.. code-block:: none
 
       ATask.machine.activate()
       ATask.machine.axisx.activate()
@@ -1551,7 +1551,7 @@ initial state and finally deactivated.
 Thus both RootMachines and SubMachines can be controlled. Some basic
 properties of the states can be inspected likewise :
 
-::
+.. code-block:: none
 
       var bool res =  ATask.machine.isActive()      // Active ?
       res = ATask.machine.axisy.isRunning()     // Running ?
@@ -1567,7 +1567,7 @@ On Reactive Mode Commands
 
 Consider the following StateMachine :
 
-::
+.. code-block:: none
 
       StateMachine X {
          // ...
@@ -1599,7 +1599,7 @@ Consider the following StateMachine :
 
 A program interacting with this StateMachine can look like this :
 
-::
+.. code-block:: none
 
        program interact {
            // First activate x :
@@ -1660,7 +1660,7 @@ Automatic Mode Commands
 
 Consider the following StateMachine, as in the previous section :
 
-::
+.. code-block:: none
 
       StateMachine X {
          // ...
@@ -1691,7 +1691,7 @@ Consider the following StateMachine, as in the previous section :
 
 A program interacting with this StateMachine can look like this :
 
-::
+.. code-block:: none
 
        program interact {
            // First activate x :
@@ -1744,7 +1744,7 @@ to exploit most common functions.
 
 The Example below shows a state machine for controlling 6 axes.
 
-::
+.. code-block:: none
 
         StateMachine Simple_nAxes_Test
         {
@@ -1835,7 +1835,7 @@ The Example below shows a state machine for controlling 6 axes.
 
 Below is a program script example.
 
-::
+.. code-block:: none
 
       /**
        * This program is executed in the exec_state.

--- a/docs/rtt/orocos-transports-corba.rst
+++ b/docs/rtt/orocos-transports-corba.rst
@@ -30,7 +30,7 @@ The Corba transport provides:
 Setup CORBA Naming (Required!)
 ==============================
 
-    **Important**
+.. important::
 
     Follow these instructions carefully or your setup will not work !
 
@@ -83,14 +83,14 @@ This is an example deployment script '``server-script.ops``' for
 creating your first process and making one component available in the
 network:
 
-::
+.. code-block:: none
 
       import("ocl")                               // make sure ocl is loaded
 
       loadComponent("MyComponent","TaskContext")  // Create a new default TaskContext
       server("MyComponent",true)                  // make MyComponent a CORBA server, and
                                                   // register it with the Naming Service ('true')
-                
+
 
 You can start this application with:
 
@@ -101,13 +101,13 @@ You can start this application with:
 In another console, start a client program '``client-script.ops``' that
 wishes to use this component:
 
-::
+.. code-block:: none
 
       import("ocl")                               // make sure ocl is loaded
 
       loadComponent("MyComponent","CORBA")        // make 'MyComponent' available in this program
-        MyComponent.start()                         // Use the component as usual...connect ports etc.
-                
+      MyComponent.start()                         // Use the component as usual...connect ports etc.
+
 
 You can start this application with:
 
@@ -161,7 +161,7 @@ The following limitations apply:
 Code Examples
 =============
 
-    **Note**
+.. note::
 
     You only need this example code if you don't use the deployer
     application!
@@ -176,7 +176,7 @@ different computers, given that a network connection exists.
 In order to setup your component to be available to other components
 *transparantly*, proceed as:
 
-::
+.. code-block:: cpp
 
       // server.cpp
       #include <rtt/transports/corba/TaskContextServer.hpp>
@@ -202,16 +202,16 @@ In order to setup your component to be available to other components
 
          // Wait for requests:
          TaskContextServer::RunOrb();
-          
+
          // Cleanup Corba:
          TaskContextServer::DestroyOrb();
          return 0;
-      } 
+      }
 
 Next, in order to connect to your component, you need to create a
 'proxy' in another file:
 
-::
+.. code-block:: cpp
 
       // client.cpp
       #include <rtt/transports/corba/TaskContextServer.hpp>
@@ -243,7 +243,7 @@ Next, in order to connect to your component, you need to create a
          // Cleanup Corba:
          TaskContextServer::DestroyOrb();
          return 0;
-      } 
+      }
 
 Both examples can be found in the ``corba-example`` package on
 Orocos.org. You may use 'connectPeers' and the related methods to form
@@ -265,7 +265,7 @@ CORBA object type.
 
 In order to provide the ORB-wide timeout value in seconds, use:
 
-::
+.. code-block:: cpp
 
         // Wait no more than 0.1 seconds for a response.
         ApplicationSetup::InitORB(argc, argv, 0.1);
@@ -333,11 +333,11 @@ use it. Instead, it is better started via some extra lines in
 
 .. code-block:: bash
 
-      ################################################################################
-      #  Start CORBA Naming Service
-      echo Starting CORBA Naming Service
-      pidof Naming_Service || Naming_Service -m 0 -ORBListenEndpoints iiop://192.168.246.151:2809 -ORBDaemon
-      ################################################################################ 
+   ################################################################################
+   #  Start CORBA Naming Service
+   echo Starting CORBA Naming Service
+   pidof Naming_Service || Naming_Service -m 0 -ORBListenEndpoints iiop://192.168.246.151:2809 -ORBDaemon
+   ################################################################################
 
 Where 192.168.246.151 should of course be replaced by your ip adres
 (using a hostname may yield trouble due to the new 127.0.1.1 entries in
@@ -349,14 +349,14 @@ NameServiceIOR
 
 .. code-block:: bash
 
-      [user@host ~]$ echo $NameServiceIOR
-      corbaloc:iiop:192.168.246.151:2809/NameService 
+   [user@host ~]$ echo $NameServiceIOR
+   corbaloc:iiop:192.168.246.151:2809/NameService
 
 You can set it f.i. in your .bashrc file or on the command line via
 
 .. code-block:: bash
 
-      export NameServiceIOR=corbaloc:iiop:192.168.246.151:2809/NameService
+   export NameServiceIOR=corbaloc:iiop:192.168.246.151:2809/NameService
 
 See the orocos website for more information on compiling/running the
 ktaskbrowser.

--- a/docs/rtt/orocos-transports-mqueue.rst
+++ b/docs/rtt/orocos-transports-mqueue.rst
@@ -62,7 +62,7 @@ Transporting 'simple' data types
 Simple data types without pointers or dynamically sized objects, can be
 transported quite easily. They are added as such:
 
-::
+.. code-block:: cpp
 
       // myapp.cpp
       #include <rtt/types/TemplateTypeInfo.hpp>
@@ -106,7 +106,7 @@ uses the boost::serialization library for this. This library already
 understands the standard containers (vector,list,...) and is easily
 extendable to learn your types. Adding complex data goes as such:
 
-::
+.. code-block:: cpp
 
       // myapp.cpp
       #include <rtt/types/TemplateTypeInfo.hpp>
@@ -178,7 +178,7 @@ use the createStream function to setup a data flow stream in each
 process. This requires you to choose a name of the connection and use
 this name in both processes:
 
-::
+.. code-block:: cpp
 
     // process1.cpp:
 
@@ -251,7 +251,7 @@ So it's more robust, but it requires the CORBA transport.
 
 An Out-Of-Band connection is always setup like this:
 
-::
+.. code-block:: cpp
 
       TaskContext *task_a, *task_b;
       // init task_a, task_b...
@@ -285,7 +285,7 @@ over the mqueue transport, the workflow is fairly identical. The code
 below is for C++, but the equivalent can be done in any CORBA enabled
 language:
 
-::
+.. code-block:: cpp
 
       #include <rtt/transports/corba/CorbaConnPolicy.hpp>
       // ...
@@ -317,7 +317,7 @@ Alternatively, you can use the create streams functions directly from
 the CORBA interface, in order to create unmanaged streams. In that case,
 the code becomes:
 
-::
+.. code-block:: cpp
 
       #include <rtt/transports/corba/CorbaConnPolicy.hpp>
       // ...


### PR DESCRIPTION
This PR includes fixes for formatting mistakes, mostly using `.. code-block:`, `.. important::`, and `.. note::` in a more consistent way.