### PR TITLE
add basic readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_build:
+      - echo "Build on `date`"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION

# Read the docs configuration file

Recently, Readthedocs has announced that the new version of the configuration file `.readthedocs.yaml` v2 will be mandatory.
This will take into effect on 25/09/2023.

Reference:
[Migrate to V2 post](https://blog.readthedocs.com/migrate-configuration-v2/)

In preparation to that, this patch provides said file with format v2, following the specification of [Configuration file v2](https://docs.readthedocs.io/en/stable/config-file/v2.html).

This PR is tested in:
[spd-intermodalics-demo](https://spd-intermodalics-demo.readthedocs.io/en/add-readthedocs-conf/).